### PR TITLE
Prefix xml custom attributes to avoid conflicts with other libraries

### DIFF
--- a/demo/src/main/res/layout/fragment_sample.xml
+++ b/demo/src/main/res/layout/fragment_sample.xml
@@ -23,10 +23,10 @@
                 android:layout_height="wrap_content"
                 android:layout_margin="10dp"
                 android:orientation="horizontal"
-                segmentedgroup:border_width="1dp"
-                segmentedgroup:corner_radius="10dp"
-                segmentedgroup:tint_color="#FFEB3B"
-                segmentedgroup:checked_text_color="#7C4DFF">
+                segmentedgroup:sc_border_width="1dp"
+                segmentedgroup:sc_corner_radius="10dp"
+                segmentedgroup:sc_tint_color="#FFEB3B"
+                segmentedgroup:sc_checked_text_color="#7C4DFF">
 
                 <RadioButton
                     android:id="@+id/button21"
@@ -60,9 +60,9 @@
                 android:layout_height="wrap_content"
                 android:layout_margin="10dp"
                 android:orientation="horizontal"
-                segmentedgroup:border_width="1dp"
-                segmentedgroup:corner_radius="5dp"
-                segmentedgroup:tint_color="#009688">
+                segmentedgroup:sc_border_width="1dp"
+                segmentedgroup:sc_corner_radius="5dp"
+                segmentedgroup:sc_tint_color="#009688">
 
                 <RadioButton
                     android:id="@+id/button31"
@@ -107,9 +107,9 @@
                     android:layout_height="wrap_content"
                     android:layout_margin="10dp"
                     android:orientation="vertical"
-                    segmentedgroup:tint_color="#727272"
-                    segmentedgroup:border_width="1dp"
-                    segmentedgroup:corner_radius="10dp">
+                    segmentedgroup:sc_tint_color="#727272"
+                    segmentedgroup:sc_border_width="1dp"
+                    segmentedgroup:sc_corner_radius="10dp">
 
                     <RadioButton
                         android:layout_width="match_parent"
@@ -141,9 +141,9 @@
                     android:layout_height="wrap_content"
                     android:layout_margin="10dp"
                     android:orientation="vertical"
-                    segmentedgroup:tint_color="#ff33b5e5"
-                    segmentedgroup:border_width="5dp"
-                    segmentedgroup:corner_radius="7dp">
+                    segmentedgroup:sc_tint_color="#ff33b5e5"
+                    segmentedgroup:sc_border_width="5dp"
+                    segmentedgroup:sc_corner_radius="7dp">
 
                     <RadioButton
                         android:layout_width="match_parent"
@@ -185,8 +185,8 @@
                     android:layout_height="wrap_content"
                     android:layout_margin="10dp"
                     android:orientation="horizontal"
-                    segmentedgroup:tint_color="@android:color/white"
-                    segmentedgroup:checked_text_color="#ff33b5e5">
+                    segmentedgroup:sc_tint_color="@android:color/white"
+                    segmentedgroup:sc_checked_text_color="#ff33b5e5">
 
                 </info.hoang8f.android.segmented.SegmentedGroup>
             </RelativeLayout>

--- a/library/src/main/java/info/hoang8f/android/segmented/SegmentedGroup.java
+++ b/library/src/main/java/info/hoang8f/android/segmented/SegmentedGroup.java
@@ -43,19 +43,19 @@ public class SegmentedGroup extends RadioGroup {
 
         try {
             mMarginDp = (int) typedArray.getDimension(
-                    R.styleable.SegmentedGroup_border_width,
+                    R.styleable.SegmentedGroup_sc_border_width,
                     getResources().getDimension(R.dimen.radio_button_stroke_border));
 
             mCornerRadius = typedArray.getDimension(
-                    R.styleable.SegmentedGroup_corner_radius,
+                    R.styleable.SegmentedGroup_sc_corner_radius,
                     getResources().getDimension(R.dimen.radio_button_conner_radius));
 
             mTintColor = typedArray.getColor(
-                    R.styleable.SegmentedGroup_tint_color,
+                    R.styleable.SegmentedGroup_sc_tint_color,
                     getResources().getColor(R.color.radio_button_selected_color));
 
             mCheckedTextColor = typedArray.getColor(
-                    R.styleable.SegmentedGroup_checked_text_color,
+                    R.styleable.SegmentedGroup_sc_checked_text_color,
                     getResources().getColor(android.R.color.white));
 
         } finally {

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <declare-styleable name="SegmentedGroup">
-        <attr name="corner_radius" format="dimension" />
-        <attr name="border_width" format="dimension" />
-        <attr name="tint_color" format="color" />
-        <attr name="checked_text_color" format="color" />
+        <attr name="sc_corner_radius" format="dimension" />
+        <attr name="sc_border_width" format="dimension" />
+        <attr name="sc_tint_color" format="color" />
+        <attr name="sc_checked_text_color" format="color" />
     </declare-styleable>
 
 </resources>


### PR DESCRIPTION
See https://code.google.com/p/android/issues/detail?id=22576

A lot of libraries use `border_width`.