### PR TITLE
Removing redundant LayoutParam creation.

### DIFF
--- a/library/src/main/java/info/hoang8f/android/segmented/SegmentedGroup.java
+++ b/library/src/main/java/info/hoang8f/android/segmented/SegmentedGroup.java
@@ -100,15 +100,14 @@ public class SegmentedGroup extends RadioGroup {
             // If this is the last view, don't set LayoutParams
             if (i == count - 1) break;
 
-            LayoutParams initParams = (LayoutParams) child.getLayoutParams();
-            LayoutParams params = new LayoutParams(initParams.width, initParams.height, initParams.weight);
+            LayoutParams params = (LayoutParams) child.getLayoutParams();
             // Check orientation for proper margins
             if (getOrientation() == LinearLayout.HORIZONTAL) {
                 params.setMargins(0, 0, -mMarginDp, 0);
             } else {
                 params.setMargins(0, 0, 0, -mMarginDp);
             }
-            child.setLayoutParams(params);
+            child.requestLayout();
         }
     }
 


### PR DESCRIPTION
Hi guys,

I believe creating new layout params in the `updateBackground()` is redundant. 

I was also tempted to change
```
params.setMargins(0, 0, -mMarginDp, 0);
params.setMargins(0, 0, 0, -mMarginDp);
```
to 
```
params.rightMargin = -mMarginDp;
params.bottomMargin = -mMarginDp;
```

but I'm not sure if setting other margins to 0 was done on purpose. If not, maybe this shouldn't be reset to 0, since the user might have set the margins?

